### PR TITLE
Fix SubwordField UNK encoding error

### DIFF
--- a/supar/utils/field.py
+++ b/supar/utils/field.py
@@ -303,7 +303,7 @@ class SubwordField(Field):
         if self.fix_len <= 0:
             self.fix_len = max(len(token) for seq in sequences for token in seq)
         if self.use_vocab:
-            sequences = [[[self.vocab[i] for i in token] if token else [self.unk] for token in seq]
+            sequences = [[[self.vocab[i] for i in token] if token else [self.unk_index] for token in seq]
                          for seq in sequences]
         if self.bos:
             sequences = [[[self.bos_index]] + seq for seq in sequences]


### PR DESCRIPTION
First of all, thanks for this very clean implementation!

Upon running the biaffine dependency parser on Russian GSD treebank (using bert-base-multilingual-uncased), I've ran into a bug when preparing text for training:
`ValueError: too many dimensions 'str'`.

The problem seemed to be that the string version of `UNK` token was being used as encoding instead of its int version.